### PR TITLE
Fix flaky test on EnvironmentalReadingStatsControllerIT.shouldReturn200AndAverageTemperaturesAsMapForQuarterHourly

### DIFF
--- a/src/test/java/com/unconv/spring/utils/EnvironmentalReadingStatsUtils.java
+++ b/src/test/java/com/unconv/spring/utils/EnvironmentalReadingStatsUtils.java
@@ -76,7 +76,7 @@ public class EnvironmentalReadingStatsUtils {
 
     public static List<EnvironmentalReading> generateMockDataForQuarterHourlyStats(
             SensorSystem sensorSystem, int listLength) {
-        return generateMockDataForStats(sensorSystem, listLength, Duration.ofHours(24));
+        return generateMockDataForStats(sensorSystem, listLength, Duration.ofHours(3));
     }
 
     public static Map<OffsetDateTime, Double> calculateAverageTempsForQuarterHourly(


### PR DESCRIPTION
…e required interval

The readings were generated for 24 hours, whereas the tests were meant for readings within 3 hour threshold, causing the tests to fail.

Fix it by generating readings within threshold duration of three hours.