### PR TITLE
Assert masked SensorAuthToken in responses

### DIFF
--- a/src/main/java/com/unconv/spring/service/SensorAuthTokenService.java
+++ b/src/main/java/com/unconv/spring/service/SensorAuthTokenService.java
@@ -30,6 +30,12 @@ public interface SensorAuthTokenService {
      */
     Optional<SensorAuthToken> findSensorAuthTokenById(UUID id);
 
+    /**
+     * Retrieves a SensorAuthTokenDTO by its ID.
+     *
+     * @param id The ID of the SensorAuthToken.
+     * @return An Optional containing the SensorAuthTokenDTO, or empty if not found.
+     */
     Optional<SensorAuthTokenDTO> findSensorAuthTokenDTOById(UUID id);
 
     /**

--- a/src/main/java/com/unconv/spring/service/SensorAuthTokenService.java
+++ b/src/main/java/com/unconv/spring/service/SensorAuthTokenService.java
@@ -13,6 +13,8 @@ public interface SensorAuthTokenService {
 
     Optional<SensorAuthToken> findSensorAuthTokenById(UUID id);
 
+    Optional<SensorAuthTokenDTO> findSensorAuthTokenDTOById(UUID id);
+
     SensorAuthToken saveSensorAuthToken(SensorAuthToken sensorAuthToken);
 
     SensorAuthTokenDTO saveSensorAuthTokenDTO(SensorAuthToken sensorAuthToken);

--- a/src/main/java/com/unconv/spring/service/impl/SensorAuthTokenServiceImpl.java
+++ b/src/main/java/com/unconv/spring/service/impl/SensorAuthTokenServiceImpl.java
@@ -61,6 +61,21 @@ public class SensorAuthTokenServiceImpl implements SensorAuthTokenService {
     }
 
     @Override
+    public Optional<SensorAuthTokenDTO> findSensorAuthTokenDTOById(UUID id) {
+        Optional<SensorAuthToken> optionalSensorAuthToken = sensorAuthTokenRepository.findById(id);
+        if (optionalSensorAuthToken.isPresent()) {
+            SensorAuthToken sensorAuthToken = optionalSensorAuthToken.get();
+            String maskedAuthToken =
+                    TOKEN_PREFIX + "*".repeat(TOKEN_LENGTH) + sensorAuthToken.getTokenHash();
+            SensorAuthTokenDTO sensorAuthTokenDTO =
+                    modelMapper.map(sensorAuthToken, SensorAuthTokenDTO.class);
+            sensorAuthTokenDTO.setAuthToken(maskedAuthToken);
+            return Optional.of(sensorAuthTokenDTO);
+        }
+        return Optional.empty();
+    }
+
+    @Override
     public SensorAuthToken saveSensorAuthToken(SensorAuthToken sensorAuthToken) {
         sensorAuthToken.setAuthToken(
                 bCryptPasswordEncoder().encode(sensorAuthToken.getAuthToken()));

--- a/src/main/java/com/unconv/spring/web/rest/SensorAuthTokenController.java
+++ b/src/main/java/com/unconv/spring/web/rest/SensorAuthTokenController.java
@@ -73,9 +73,9 @@ public class SensorAuthTokenController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<SensorAuthToken> getSensorAuthTokenById(@PathVariable UUID id) {
+    public ResponseEntity<SensorAuthTokenDTO> getSensorAuthTokenById(@PathVariable UUID id) {
         return sensorAuthTokenService
-                .findSensorAuthTokenById(id)
+                .findSensorAuthTokenDTOById(id)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
@@ -144,9 +144,9 @@ public class SensorAuthTokenController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<SensorAuthToken> deleteSensorAuthToken(@PathVariable UUID id) {
+    public ResponseEntity<SensorAuthTokenDTO> deleteSensorAuthToken(@PathVariable UUID id) {
         return sensorAuthTokenService
-                .findSensorAuthTokenById(id)
+                .findSensorAuthTokenDTOById(id)
                 .map(
                         sensorAuthToken -> {
                             sensorAuthTokenService.deleteSensorAuthTokenById(id);

--- a/src/test/java/com/unconv/spring/matchers/SensorAuthTokenMatcher.java
+++ b/src/test/java/com/unconv/spring/matchers/SensorAuthTokenMatcher.java
@@ -1,0 +1,25 @@
+package com.unconv.spring.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+public class SensorAuthTokenMatcher {
+
+    public static Matcher<Object> validSensorAuthToken() {
+        return new TypeSafeMatcher<>() {
+
+            @Override
+            protected boolean matchesSafely(Object object) {
+                String sensorAuthTokenString = (String) object;
+                String maskedSensorAuthTokenPattern = "UNCONV[A-Za-z0-9*]{19}.*";
+                return sensorAuthTokenString.matches(maskedSensorAuthTokenPattern);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("A valid SensorAuthToken");
+            }
+        };
+    }
+}

--- a/src/test/java/com/unconv/spring/matchers/SensorAuthTokenMatcher.java
+++ b/src/test/java/com/unconv/spring/matchers/SensorAuthTokenMatcher.java
@@ -13,7 +13,7 @@ public class SensorAuthTokenMatcher {
             protected boolean matchesSafely(Object object) {
                 String sensorAuthTokenString = (String) object;
                 String maskedSensorAuthTokenPattern = "UNCONV[*]{19}[A-Za-z0-9+/]{22}==";
-                String unmaskedSensorAuthTokenPattern = "UNCONV[A-Za-z0-9]{19}.*";
+                String unmaskedSensorAuthTokenPattern = "UNCONV[A-Za-z0-9]{19}[A-Za-z0-9+/]{22}==";
 
                 String selectedPattern =
                         isMaskedSensorAuthToken

--- a/src/test/java/com/unconv/spring/matchers/SensorAuthTokenMatcher.java
+++ b/src/test/java/com/unconv/spring/matchers/SensorAuthTokenMatcher.java
@@ -13,13 +13,23 @@ public class SensorAuthTokenMatcher {
             protected boolean matchesSafely(Object object) {
                 String sensorAuthTokenString = (String) object;
                 String maskedSensorAuthTokenPattern = "UNCONV[A-Za-z0-9*]{19}.*";
-                return sensorAuthTokenString.matches(maskedSensorAuthTokenPattern)
+                String unmaskedSensorAuthTokenPattern = "UNCONV[A-Za-z0-9]{19}.*";
+
+                String selectedPattern =
+                        isMaskedSensorAuthToken
+                                ? maskedSensorAuthTokenPattern
+                                : unmaskedSensorAuthTokenPattern;
+
+                return sensorAuthTokenString.matches(selectedPattern)
                         && sensorAuthTokenString.length() == 49;
             }
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("A valid SensorAuthToken");
+                description
+                        .appendText("A valid SensorAuthToken matching ")
+                        .appendText(
+                                isMaskedSensorAuthToken ? "masked pattern" : "unmasked pattern");
             }
         };
     }

--- a/src/test/java/com/unconv/spring/matchers/SensorAuthTokenMatcher.java
+++ b/src/test/java/com/unconv/spring/matchers/SensorAuthTokenMatcher.java
@@ -6,7 +6,7 @@ import org.hamcrest.TypeSafeMatcher;
 
 public class SensorAuthTokenMatcher {
 
-    public static Matcher<Object> validSensorAuthToken() {
+    public static Matcher<Object> validSensorAuthToken(boolean isMaskedSensorAuthToken) {
         return new TypeSafeMatcher<>() {
 
             @Override

--- a/src/test/java/com/unconv/spring/matchers/SensorAuthTokenMatcher.java
+++ b/src/test/java/com/unconv/spring/matchers/SensorAuthTokenMatcher.java
@@ -12,8 +12,9 @@ public class SensorAuthTokenMatcher {
             @Override
             protected boolean matchesSafely(Object object) {
                 String sensorAuthTokenString = (String) object;
-                String maskedSensorAuthTokenPattern = "UNCONV[*]{19}[A-Za-z0-9+/]{22}==";
-                String unmaskedSensorAuthTokenPattern = "UNCONV[A-Za-z0-9]{19}[A-Za-z0-9+/]{22}==";
+                String maskedSensorAuthTokenPattern = "^UNCONV[*]{19}[A-Za-z0-9+/]{22}==$";
+                String unmaskedSensorAuthTokenPattern =
+                        "^UNCONV[A-Za-z0-9]{19}[A-Za-z0-9+/]{22}==$";
 
                 String selectedPattern =
                         isMaskedSensorAuthToken

--- a/src/test/java/com/unconv/spring/matchers/SensorAuthTokenMatcher.java
+++ b/src/test/java/com/unconv/spring/matchers/SensorAuthTokenMatcher.java
@@ -13,7 +13,8 @@ public class SensorAuthTokenMatcher {
             protected boolean matchesSafely(Object object) {
                 String sensorAuthTokenString = (String) object;
                 String maskedSensorAuthTokenPattern = "UNCONV[A-Za-z0-9*]{19}.*";
-                return sensorAuthTokenString.matches(maskedSensorAuthTokenPattern);
+                return sensorAuthTokenString.matches(maskedSensorAuthTokenPattern)
+                        && sensorAuthTokenString.length() == 49;
             }
 
             @Override

--- a/src/test/java/com/unconv/spring/matchers/SensorAuthTokenMatcher.java
+++ b/src/test/java/com/unconv/spring/matchers/SensorAuthTokenMatcher.java
@@ -12,7 +12,7 @@ public class SensorAuthTokenMatcher {
             @Override
             protected boolean matchesSafely(Object object) {
                 String sensorAuthTokenString = (String) object;
-                String maskedSensorAuthTokenPattern = "UNCONV[A-Za-z0-9*]{19}.*";
+                String maskedSensorAuthTokenPattern = "UNCONV[*]{19}[A-Za-z0-9+/]{22}==";
                 String unmaskedSensorAuthTokenPattern = "UNCONV[A-Za-z0-9]{19}.*";
 
                 String selectedPattern =

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerIT.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerIT.java
@@ -6,7 +6,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.hasLength;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.instancio.Select.field;
@@ -167,7 +166,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id", notNullValue()))
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9]{19}.*")))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken(false)))
                 .andReturn();
     }
 
@@ -214,7 +213,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", is(sensorAuthToken.getId().toString())))
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9]{19}.*")))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken(false)))
                 .andReturn();
     }
 
@@ -281,8 +280,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.message", is("Generated New Sensor Auth Token")))
                 .andExpect(jsonPath("$.entity.id", notNullValue()))
                 .andExpect(jsonPath("$.entity.authToken", hasLength(49)))
-                .andExpect(
-                        jsonPath("$.entity.authToken", matchesPattern("UNCONV[A-Za-z0-9]{19}.*")))
+                .andExpect(jsonPath("$.entity.authToken", validSensorAuthToken(false)))
                 .andExpect(
                         jsonPath("$.entity.sensorSystem.id", is(sensorSystem.getId().toString())))
                 .andReturn();
@@ -314,8 +312,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.entity.id", notNullValue()))
                 .andExpect(jsonPath("$.entity.id", not(sensorAuthToken.getId().toString())))
                 .andExpect(jsonPath("$.entity.authToken", hasLength(49)))
-                .andExpect(
-                        jsonPath("$.entity.authToken", matchesPattern("UNCONV[A-Za-z0-9]{19}.*")))
+                .andExpect(jsonPath("$.entity.authToken", validSensorAuthToken(false)))
                 .andExpect(
                         jsonPath("$.entity.sensorSystem.id", is(sensorSystem.getId().toString())))
                 .andReturn();

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerIT.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerIT.java
@@ -30,8 +30,6 @@ import com.unconv.spring.persistence.SensorSystemRepository;
 import com.unconv.spring.persistence.UnconvUserRepository;
 import com.unconv.spring.service.SensorAuthTokenService;
 import com.unconv.spring.service.UnconvUserService;
-import com.unconv.spring.utils.AccessTokenGenerator;
-import com.unconv.spring.utils.SaltedSuffixGenerator;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,7 +60,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
 
     private SensorSystem savedSensorSystem;
 
-    private List<SensorAuthToken> sensorAuthTokenList = null;
+    private List<SensorAuthTokenDTO> sensorAuthTokenList = null;
 
     @BeforeEach
     void setUp() {
@@ -94,16 +92,10 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
 
         sensorAuthTokenList = new ArrayList<>();
         for (SensorSystem sensorSystem : sensorSystemList) {
-            SensorAuthToken sensorAuthToken =
-                    new SensorAuthToken(
-                            null,
-                            AccessTokenGenerator.generateAccessToken(),
-                            OffsetDateTime.now().plusDays(10),
-                            SaltedSuffixGenerator.generateSaltedSuffix(),
-                            sensorSystem);
-            sensorAuthTokenList.add(sensorAuthToken);
+            SensorAuthTokenDTO sensorAuthTokenDTO =
+                    sensorAuthTokenService.generateSensorAuthToken(sensorSystem, null);
+            sensorAuthTokenList.add(sensorAuthTokenDTO);
         }
-        sensorAuthTokenList = sensorAuthTokenRepository.saveAll(sensorAuthTokenList);
     }
 
     @Test
@@ -138,7 +130,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
 
     @Test
     void shouldFindSensorAuthTokenById() throws Exception {
-        SensorAuthToken sensorAuthToken = sensorAuthTokenList.get(0);
+        SensorAuthTokenDTO sensorAuthToken = sensorAuthTokenList.get(0);
         UUID sensorAuthTokenId = sensorAuthToken.getId();
 
         this.mockMvc
@@ -209,7 +201,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
 
     @Test
     void shouldUpdateSensorAuthToken() throws Exception {
-        SensorAuthToken sensorAuthToken = sensorAuthTokenList.get(0);
+        SensorAuthTokenDTO sensorAuthToken = sensorAuthTokenList.get(0);
         sensorAuthToken.setAuthToken("Updated SensorAuthToken");
         sensorAuthToken.setExpiry(OffsetDateTime.now().plusDays(100));
 
@@ -228,7 +220,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
 
     @Test
     void shouldDeleteSensorAuthToken() throws Exception {
-        SensorAuthToken sensorAuthToken = sensorAuthTokenList.get(0);
+        SensorAuthTokenDTO sensorAuthToken = sensorAuthTokenList.get(0);
 
         this.mockMvc
                 .perform(delete("/SensorAuthToken/{id}", sensorAuthToken.getId()).with(csrf()))
@@ -250,7 +242,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
     @Test
     void shouldReturn404WhenUpdatingNonExistingSensorAuthToken() throws Exception {
         UUID sensorAuthTokenId = UUID.randomUUID();
-        SensorAuthToken sensorAuthToken = sensorAuthTokenList.get(1);
+        SensorAuthTokenDTO sensorAuthToken = sensorAuthTokenList.get(1);
 
         this.mockMvc
                 .perform(

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerIT.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerIT.java
@@ -137,8 +137,8 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .perform(get("/SensorAuthToken/{id}", sensorAuthTokenId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", is(sensorAuthToken.getId().toString())))
-                .andExpect(jsonPath("$.authToken", hasLength(25)))
-                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9]+")))
+                .andExpect(jsonPath("$.authToken", hasLength(49)))
+                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9*]{19}.*")))
                 .andReturn();
     }
 
@@ -226,8 +226,8 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .perform(delete("/SensorAuthToken/{id}", sensorAuthToken.getId()).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", is(sensorAuthToken.getId().toString())))
-                .andExpect(jsonPath("$.authToken", hasLength(25)))
-                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9]+")))
+                .andExpect(jsonPath("$.authToken", hasLength(49)))
+                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9*]{19}.*")))
                 .andReturn();
     }
 

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerIT.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerIT.java
@@ -1,6 +1,7 @@
 package com.unconv.spring.web.controllers;
 
 import static com.unconv.spring.enums.DefaultUserRole.UNCONV_USER;
+import static com.unconv.spring.matchers.SensorAuthTokenMatcher.validSensorAuthToken;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.hasLength;
@@ -138,7 +139,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", is(sensorAuthToken.getId().toString())))
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9*]{19}.*")))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken()))
                 .andReturn();
     }
 
@@ -227,7 +228,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", is(sensorAuthToken.getId().toString())))
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9*]{19}.*")))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken()))
                 .andReturn();
     }
 
@@ -365,7 +366,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.id", notNullValue()))
                 .andExpect(jsonPath("$.id", is(sensorAuthTokenUUID.toString())))
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9*]{19}.*")))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken()))
                 .andExpect(jsonPath("$.expiry", notNullValue(OffsetDateTime.class)))
                 .andExpect(jsonPath("$.sensorSystem.id", is(sensorSystem.getId().toString())))
                 .andReturn();

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerIT.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerIT.java
@@ -4,7 +4,6 @@ import static com.unconv.spring.enums.DefaultUserRole.UNCONV_USER;
 import static com.unconv.spring.matchers.SensorAuthTokenMatcher.validSensorAuthToken;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.Matchers.hasLength;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -165,7 +164,6 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                                 .content(objectMapper.writeValueAsString(sensorAuthToken)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id", notNullValue()))
-                .andExpect(jsonPath("$.authToken", hasLength(49)))
                 .andExpect(jsonPath("$.authToken", validSensorAuthToken(false)))
                 .andReturn();
     }
@@ -212,7 +210,6 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                                 .content(objectMapper.writeValueAsString(sensorAuthToken)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", is(sensorAuthToken.getId().toString())))
-                .andExpect(jsonPath("$.authToken", hasLength(49)))
                 .andExpect(jsonPath("$.authToken", validSensorAuthToken(false)))
                 .andReturn();
     }
@@ -279,7 +276,6 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.message", is("Generated New Sensor Auth Token")))
                 .andExpect(jsonPath("$.entity.id", notNullValue()))
-                .andExpect(jsonPath("$.entity.authToken", hasLength(49)))
                 .andExpect(jsonPath("$.entity.authToken", validSensorAuthToken(false)))
                 .andExpect(
                         jsonPath("$.entity.sensorSystem.id", is(sensorSystem.getId().toString())))
@@ -311,7 +307,6 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.message", is("Generated New Sensor Auth Token")))
                 .andExpect(jsonPath("$.entity.id", notNullValue()))
                 .andExpect(jsonPath("$.entity.id", not(sensorAuthToken.getId().toString())))
-                .andExpect(jsonPath("$.entity.authToken", hasLength(49)))
                 .andExpect(jsonPath("$.entity.authToken", validSensorAuthToken(false)))
                 .andExpect(
                         jsonPath("$.entity.sensorSystem.id", is(sensorSystem.getId().toString())))

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerIT.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerIT.java
@@ -138,7 +138,6 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .perform(get("/SensorAuthToken/{id}", sensorAuthTokenId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", is(sensorAuthToken.getId().toString())))
-                .andExpect(jsonPath("$.authToken", hasLength(49)))
                 .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                 .andReturn();
     }
@@ -227,7 +226,6 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .perform(delete("/SensorAuthToken/{id}", sensorAuthToken.getId()).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", is(sensorAuthToken.getId().toString())))
-                .andExpect(jsonPath("$.authToken", hasLength(49)))
                 .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                 .andReturn();
     }
@@ -365,7 +363,6 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", notNullValue()))
                 .andExpect(jsonPath("$.id", is(sensorAuthTokenUUID.toString())))
-                .andExpect(jsonPath("$.authToken", hasLength(49)))
                 .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                 .andExpect(jsonPath("$.expiry", notNullValue(OffsetDateTime.class)))
                 .andExpect(jsonPath("$.sensorSystem.id", is(sensorSystem.getId().toString())))

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerIT.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerIT.java
@@ -139,7 +139,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", is(sensorAuthToken.getId().toString())))
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", validSensorAuthToken()))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                 .andReturn();
     }
 
@@ -228,7 +228,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", is(sensorAuthToken.getId().toString())))
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", validSensorAuthToken()))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                 .andReturn();
     }
 
@@ -366,7 +366,7 @@ class SensorAuthTokenControllerIT extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.id", notNullValue()))
                 .andExpect(jsonPath("$.id", is(sensorAuthTokenUUID.toString())))
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", validSensorAuthToken()))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                 .andExpect(jsonPath("$.expiry", notNullValue(OffsetDateTime.class)))
                 .andExpect(jsonPath("$.sensorSystem.id", is(sensorSystem.getId().toString())))
                 .andReturn();

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
@@ -2,6 +2,7 @@ package com.unconv.spring.web.controllers;
 
 import static com.unconv.spring.consts.AppConstants.PROFILE_TEST;
 import static com.unconv.spring.enums.DefaultUserRole.UNCONV_USER;
+import static com.unconv.spring.matchers.SensorAuthTokenMatcher.validSensorAuthToken;
 import static com.unconv.spring.utils.AccessTokenGenerator.generateAccessToken;
 import static com.unconv.spring.utils.SaltedSuffixGenerator.generateSaltedSuffix;
 import static org.hamcrest.CoreMatchers.is;
@@ -222,7 +223,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id", notNullValue()))
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9*]{19}.*")))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken()))
                 .andReturn();
     }
 
@@ -294,7 +295,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                                 preprocessResponse(prettyPrint)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9*]{19}.*")))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken()))
                 .andReturn();
     }
 
@@ -344,7 +345,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                 .andDo(document("shouldDeleteSensorAuthToken", preprocessResponse(prettyPrint)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9*]{19}.*")))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken()))
                 .andReturn();
     }
 
@@ -399,8 +400,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                 .andExpect(jsonPath("$.message", is("Generated New Sensor Auth Token")))
                 .andExpect(jsonPath("$.entity.id", notNullValue()))
                 .andExpect(jsonPath("$.entity.authToken", hasLength(49)))
-                .andExpect(
-                        jsonPath("$.entity.authToken", matchesPattern("UNCONV[A-Za-z0-9*]{19}.*")))
+                .andExpect(jsonPath("$.entity.authToken", validSensorAuthToken()))
                 .andExpect(
                         jsonPath("$.entity.sensorSystem.id", is(sensorSystem.getId().toString())))
                 .andReturn();
@@ -461,7 +461,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                 .andExpect(jsonPath("$.id", notNullValue()))
                 .andExpect(jsonPath("$.id", is(sensorAuthTokenDTO.getId().toString())))
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9*]{19}.*")))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken()))
                 .andExpect(jsonPath("$.expiry", notNullValue(OffsetDateTime.class)))
                 .andExpect(jsonPath("$.sensorSystem.id", is(sensorSystem.getId().toString())))
                 .andReturn();

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
@@ -7,7 +7,6 @@ import static com.unconv.spring.utils.AccessTokenGenerator.generateAccessToken;
 import static com.unconv.spring.utils.SaltedSuffixGenerator.generateSaltedSuffix;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.hasLength;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.instancio.Select.field;
@@ -161,7 +160,6 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                                         preprocessResponse(prettyPrint)))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.id", is(sensorAuthTokenId.toString())))
-                        .andExpect(jsonPath("$.authToken", hasLength(49)))
                         .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                         .andReturn()
                         .getResponse()

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.hasLength;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.instancio.Select.field;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -163,8 +162,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.id", is(sensorAuthTokenId.toString())))
                         .andExpect(jsonPath("$.authToken", hasLength(49)))
-                        .andExpect(
-                                jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9]{19}.*")))
+                        .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                         .andReturn()
                         .getResponse()
                         .getContentAsString();
@@ -222,7 +220,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                                 preprocessResponse(prettyPrint)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id", notNullValue()))
-                .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken(false)))
                 .andReturn();
     }
 
@@ -293,7 +291,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                                 preprocessRequest(prettyPrint),
                                 preprocessResponse(prettyPrint)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken(false)))
                 .andReturn();
     }
 
@@ -396,7 +394,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.message", is("Generated New Sensor Auth Token")))
                 .andExpect(jsonPath("$.entity.id", notNullValue()))
-                .andExpect(jsonPath("$.entity.authToken", validSensorAuthToken(true)))
+                .andExpect(jsonPath("$.entity.authToken", validSensorAuthToken(false)))
                 .andExpect(
                         jsonPath("$.entity.sensorSystem.id", is(sensorSystem.getId().toString())))
                 .andReturn();

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
@@ -222,7 +222,6 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                                 preprocessResponse(prettyPrint)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id", notNullValue()))
-                .andExpect(jsonPath("$.authToken", hasLength(49)))
                 .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                 .andReturn();
     }
@@ -294,7 +293,6 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                                 preprocessRequest(prettyPrint),
                                 preprocessResponse(prettyPrint)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.authToken", hasLength(49)))
                 .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                 .andReturn();
     }
@@ -344,7 +342,6 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                 .perform(delete("/SensorAuthToken/{id}", sensorAuthToken.getId()).with(csrf()))
                 .andDo(document("shouldDeleteSensorAuthToken", preprocessResponse(prettyPrint)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.authToken", hasLength(49)))
                 .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                 .andReturn();
     }
@@ -399,7 +396,6 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.message", is("Generated New Sensor Auth Token")))
                 .andExpect(jsonPath("$.entity.id", notNullValue()))
-                .andExpect(jsonPath("$.entity.authToken", hasLength(49)))
                 .andExpect(jsonPath("$.entity.authToken", validSensorAuthToken(true)))
                 .andExpect(
                         jsonPath("$.entity.sensorSystem.id", is(sensorSystem.getId().toString())))
@@ -460,7 +456,6 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", notNullValue()))
                 .andExpect(jsonPath("$.id", is(sensorAuthTokenDTO.getId().toString())))
-                .andExpect(jsonPath("$.authToken", hasLength(49)))
                 .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                 .andExpect(jsonPath("$.expiry", notNullValue(OffsetDateTime.class)))
                 .andExpect(jsonPath("$.sensorSystem.id", is(sensorSystem.getId().toString())))

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
@@ -143,14 +143,13 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
     @Test
     void shouldFindSensorAuthTokenById() throws Exception {
         UUID sensorAuthTokenId = UUID.randomUUID();
-        SensorAuthToken sensorAuthToken =
-                new SensorAuthToken(
+        SensorAuthTokenDTO sensorAuthToken =
+                new SensorAuthTokenDTO(
                         sensorAuthTokenId,
                         generateAccessToken() + RandomStringUtils.random(24),
                         OffsetDateTime.now().plusDays(30),
-                        RandomStringUtils.random(24),
                         sensorSystem);
-        given(sensorAuthTokenService.findSensorAuthTokenById(sensorAuthTokenId))
+        given(sensorAuthTokenService.findSensorAuthTokenDTOById(sensorAuthTokenId))
                 .willReturn(Optional.of(sensorAuthToken));
 
         String responseJson =
@@ -329,14 +328,14 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
     @Test
     void shouldDeleteSensorAuthToken() throws Exception {
         UUID sensorAuthTokenId = UUID.randomUUID();
-        SensorAuthToken sensorAuthToken =
-                new SensorAuthToken(
+        SensorAuthTokenDTO sensorAuthToken =
+                new SensorAuthTokenDTO(
                         sensorAuthTokenId,
                         generateAccessToken(),
                         OffsetDateTime.now().plusDays(30),
                         sensorSystem);
-        given(sensorAuthTokenService.findSensorAuthTokenById(sensorAuthTokenId))
-                .willReturn(Optional.of(sensorAuthToken));
+        given(sensorAuthTokenService.findSensorAuthTokenDTOById(sensorAuthTokenId))
+                .willReturn((Optional.of(sensorAuthToken)));
         //
         // doNothing().when(sensorAuthTokenService).deleteSensorAuthTokenById(sensorAuthToken.getId());
         //

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
@@ -146,7 +146,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
         SensorAuthTokenDTO sensorAuthToken =
                 new SensorAuthTokenDTO(
                         sensorAuthTokenId,
-                        generateAccessToken() + generateSaltedSuffix(),
+                        "UNCONV" + "*".repeat(19) + generateSaltedSuffix(),
                         OffsetDateTime.now().plusDays(30),
                         sensorSystem);
         given(sensorAuthTokenService.findSensorAuthTokenDTOById(sensorAuthTokenId))
@@ -202,7 +202,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
         SensorAuthToken sensorAuthToken =
                 new SensorAuthToken(
                         null,
-                        generateAccessToken() + generateSaltedSuffix(),
+                        "UNCONV" + "*".repeat(19) + generateSaltedSuffix(),
                         OffsetDateTime.now().plusDays(30),
                         sensorSystem);
 
@@ -328,7 +328,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
         SensorAuthTokenDTO sensorAuthToken =
                 new SensorAuthTokenDTO(
                         sensorAuthTokenId,
-                        generateAccessToken() + generateSaltedSuffix(),
+                        "UNCONV" + "*".repeat(19) + generateSaltedSuffix(),
                         OffsetDateTime.now().plusDays(30),
                         sensorSystem);
         given(sensorAuthTokenService.findSensorAuthTokenDTOById(sensorAuthTokenId))
@@ -433,7 +433,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
         SensorAuthTokenDTO sensorAuthTokenDTO =
                 new SensorAuthTokenDTO(
                         UUID.randomUUID(),
-                        generateAccessToken() + generateSaltedSuffix(),
+                        "UNCONV" + "*".repeat(19) + generateSaltedSuffix(),
                         OffsetDateTime.now().plusDays(60),
                         sensorSystem);
 

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
@@ -146,7 +146,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
         SensorAuthTokenDTO sensorAuthToken =
                 new SensorAuthTokenDTO(
                         sensorAuthTokenId,
-                        generateAccessToken() + RandomStringUtils.random(24),
+                        generateAccessToken() + generateSaltedSuffix(),
                         OffsetDateTime.now().plusDays(30),
                         sensorSystem);
         given(sensorAuthTokenService.findSensorAuthTokenDTOById(sensorAuthTokenId))
@@ -196,14 +196,14 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                         (invocation) ->
                                 new SensorAuthTokenDTO(
                                         UUID.randomUUID(),
-                                        generateAccessToken(),
+                                        generateAccessToken() + generateSaltedSuffix(),
                                         OffsetDateTime.now().plusDays(10),
                                         invocation.getArgument(0)));
 
         SensorAuthToken sensorAuthToken =
                 new SensorAuthToken(
                         null,
-                        generateAccessToken(),
+                        generateAccessToken() + generateSaltedSuffix(),
                         OffsetDateTime.now().plusDays(30),
                         sensorSystem);
 
@@ -221,8 +221,8 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                                 preprocessResponse(prettyPrint)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id", notNullValue()))
-                .andExpect(jsonPath("$.authToken", hasLength(25)))
-                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9]+")))
+                .andExpect(jsonPath("$.authToken", hasLength(49)))
+                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9*]{19}.*")))
                 .andReturn();
     }
 
@@ -277,7 +277,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                         (invocation) ->
                                 new SensorAuthTokenDTO(
                                         UUID.randomUUID(),
-                                        generateAccessToken(),
+                                        generateAccessToken() + generateSaltedSuffix(),
                                         OffsetDateTime.now().plusDays(10),
                                         invocation.getArgument(0)));
 
@@ -293,8 +293,8 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                                 preprocessRequest(prettyPrint),
                                 preprocessResponse(prettyPrint)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.authToken", hasLength(25)))
-                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9]+")))
+                .andExpect(jsonPath("$.authToken", hasLength(49)))
+                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9*]{19}.*")))
                 .andReturn();
     }
 
@@ -331,7 +331,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
         SensorAuthTokenDTO sensorAuthToken =
                 new SensorAuthTokenDTO(
                         sensorAuthTokenId,
-                        generateAccessToken(),
+                        generateAccessToken() + generateSaltedSuffix(),
                         OffsetDateTime.now().plusDays(30),
                         sensorSystem);
         given(sensorAuthTokenService.findSensorAuthTokenDTOById(sensorAuthTokenId))
@@ -343,8 +343,8 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                 .perform(delete("/SensorAuthToken/{id}", sensorAuthToken.getId()).with(csrf()))
                 .andDo(document("shouldDeleteSensorAuthToken", preprocessResponse(prettyPrint)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.authToken", hasLength(25)))
-                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9]+")))
+                .andExpect(jsonPath("$.authToken", hasLength(49)))
+                .andExpect(jsonPath("$.authToken", matchesPattern("UNCONV[A-Za-z0-9*]{19}.*")))
                 .andReturn();
     }
 
@@ -375,7 +375,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
         SensorAuthTokenDTO sensorAuthTokenDTO =
                 new SensorAuthTokenDTO(
                         UUID.randomUUID(),
-                        generateAccessToken(),
+                        generateAccessToken() + generateSaltedSuffix(),
                         OffsetDateTime.now().plusDays(60),
                         sensorSystem);
 
@@ -398,8 +398,9 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.message", is("Generated New Sensor Auth Token")))
                 .andExpect(jsonPath("$.entity.id", notNullValue()))
-                .andExpect(jsonPath("$.entity.authToken", hasLength(25)))
-                .andExpect(jsonPath("$.entity.authToken", matchesPattern("UNCONV[A-Za-z0-9]+")))
+                .andExpect(jsonPath("$.entity.authToken", hasLength(49)))
+                .andExpect(
+                        jsonPath("$.entity.authToken", matchesPattern("UNCONV[A-Za-z0-9*]{19}.*")))
                 .andExpect(
                         jsonPath("$.entity.sensorSystem.id", is(sensorSystem.getId().toString())))
                 .andReturn();

--- a/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
+++ b/src/test/java/com/unconv/spring/web/controllers/SensorAuthTokenControllerTest.java
@@ -223,7 +223,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id", notNullValue()))
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", validSensorAuthToken()))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                 .andReturn();
     }
 
@@ -295,7 +295,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                                 preprocessResponse(prettyPrint)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", validSensorAuthToken()))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                 .andReturn();
     }
 
@@ -345,7 +345,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                 .andDo(document("shouldDeleteSensorAuthToken", preprocessResponse(prettyPrint)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", validSensorAuthToken()))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                 .andReturn();
     }
 
@@ -400,7 +400,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                 .andExpect(jsonPath("$.message", is("Generated New Sensor Auth Token")))
                 .andExpect(jsonPath("$.entity.id", notNullValue()))
                 .andExpect(jsonPath("$.entity.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.entity.authToken", validSensorAuthToken()))
+                .andExpect(jsonPath("$.entity.authToken", validSensorAuthToken(true)))
                 .andExpect(
                         jsonPath("$.entity.sensorSystem.id", is(sensorSystem.getId().toString())))
                 .andReturn();
@@ -461,7 +461,7 @@ class SensorAuthTokenControllerTest extends AbstractControllerTest {
                 .andExpect(jsonPath("$.id", notNullValue()))
                 .andExpect(jsonPath("$.id", is(sensorAuthTokenDTO.getId().toString())))
                 .andExpect(jsonPath("$.authToken", hasLength(49)))
-                .andExpect(jsonPath("$.authToken", validSensorAuthToken()))
+                .andExpect(jsonPath("$.authToken", validSensorAuthToken(true)))
                 .andExpect(jsonPath("$.expiry", notNullValue(OffsetDateTime.class)))
                 .andExpect(jsonPath("$.sensorSystem.id", is(sensorSystem.getId().toString())))
                 .andReturn();


### PR DESCRIPTION
Directly saving records breaks the password encoding mechanism