### PR TITLE
Codacy coverage report

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -80,3 +80,9 @@ jobs:
         with:
           generate-branches-badge: true
           jacoco-csv-file: target/jacoco/test/jacoco.csv
+
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+            project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+            coverage-reports: ./target/jacoco/test/jacoco.xml,./target/jacoco/integrationTest/jacoco.xml


### PR DESCRIPTION
- codecov process separate units test and integrations tests both have same value
- sonar doesnt care about unit tests, only integration